### PR TITLE
Add Read-only mode

### DIFF
--- a/src/BootstrapInputAddons/BootstrapInputAddons.xml
+++ b/src/BootstrapInputAddons/BootstrapInputAddons.xml
@@ -70,6 +70,15 @@
                 <enumerationValue key="conditionally">Conditionally</enumerationValue>
             </enumerationValues>
         </property>
+        <property defaultValue="textLabel" key="readOnlyMode" type="enumeration">
+            <caption>Read-only mode</caption>
+            <category>Appearance</category>
+            <description/>
+            <enumerationValues>
+                <enumerationValue key="textLabel">Text</enumerationValue>
+                <enumerationValue key="textControl">Control</enumerationValue>
+            </enumerationValues>
+        </property>
         <property key="editableAttribute" required="false" type="attribute">
             <caption>Editable condition</caption>
             <category>Appearance</category>

--- a/src/BootstrapInputAddons/widget/BootstrapInputAddons.js
+++ b/src/BootstrapInputAddons/widget/BootstrapInputAddons.js
@@ -54,6 +54,7 @@ define([
         groupDigits: "",
         visibilityAttribute: "",
         editable: "",
+        readOnlyMode: "",
         editableAttribute: "",
         showLabel: "",
         labelCaption: "",
@@ -176,11 +177,15 @@ define([
 
                 dojoClass.add(this.inputDiv, this._getInputDivClass());
 
+                if (!this._isEditable() && this.readOnlyMode == "textControl") {
+                    dojoAttr.set(this.inputNode, "disabled", "disabled");
+                }
+
                 if (!this._isEmptyString(this.placeholderText)) {
                     dojoAttr.set(this.inputNode, "placeholder", this.placeholderText);
                 }
 
-                if (!this._isEditable()) {
+                if (!this._isEditable() && this.readOnlyMode == "textLabel") {
                     this._setReadOnlyValue(value);
                 }
 
@@ -265,7 +270,7 @@ define([
         },
 
         _addLeftAddon: function () {
-            if (this.showLeftAddon && this._isEditable()) {
+            if (this.showLeftAddon && (this._isEditable() || (!this._isEditable() && this.readOnlyMode == "textControl"))) {
                 dojoConstruct.destroy(this._leftAddonSpan);
                 this._leftAddonSpan = dojoConstruct.create("span", {
                     "class": "input-group-addon",
@@ -278,7 +283,7 @@ define([
         },
 
         _addRightAddon: function () {
-            if (this.showRightAddon && this._isEditable()) {
+            if (this.showRightAddon && (this._isEditable() || (!this._isEditable() && this.readOnlyMode == "textControl"))) {
                 dojoConstruct.destroy(this._rightAddonSpan);
                 this._rightAddonSpan = dojoConstruct.create("span", {
                     "class": "input-group-addon",


### PR DESCRIPTION
Added Read-only mode option to get the widget more in line with Mendix
6.9+, where this attribute was added to give developers more control
over how read only fields should be rendered.