### PR TITLE
Readonly value: delete space between addon captions

### DIFF
--- a/src/BootstrapInputAddons/widget/BootstrapInputAddons.js
+++ b/src/BootstrapInputAddons/widget/BootstrapInputAddons.js
@@ -487,11 +487,11 @@ define([
         _setReadOnlyValue: function (value) {
 
             if (this.showLeftAddon) {
-                value = this.leftAddonCaption + " " + value;
+                value = this.leftAddonCaption + value;
             }
 
             if (this.showRightAddon) {
-                value = value + " " + this.rightAddonCaption;
+                value = value + this.rightAddonCaption;
             }
 
             if (this.showLabel) {


### PR DESCRIPTION
Delete the forced space when connecting addon captions before/after value.
It is better to add it optionally to the addon caption field